### PR TITLE
feat: add RabbitMQ docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  rabbitmq:
+    build: ./rabbitmq
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: user
+      RABBITMQ_DEFAULT_PASS: password

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -1,0 +1,5 @@
+# RabbitMQ Dockerfile using official image with management plugin
+FROM rabbitmq:3-management
+
+# Expose default RabbitMQ ports
+EXPOSE 5672 15672


### PR DESCRIPTION
## Summary
- add docker-compose service and Dockerfile for RabbitMQ

## Testing
- `npm test` *(fails: missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2f75510688331a1dc978c1c25bf9a