### PR TITLE
Add MongoDB replica set service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,10 @@ services:
     environment:
       RABBITMQ_DEFAULT_USER: user
       RABBITMQ_DEFAULT_PASS: password
+
+  mongo:
+    image: candis/mongo-replica-set
+    ports:
+      - "27017:27017"
+      - "27018:27018"
+      - "27019:27019"


### PR DESCRIPTION
## Summary
- add `mongo` service using `candis/mongo-replica-set` image for local development

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2f95fd5688331b7c29c7d6cf58bfd